### PR TITLE
Updated gym version requirement to 0.21.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='magical-il',
       install_requires=[
           'pymunk~=5.6.0',
           'pyglet==1.5.*',
-          'gym==0.17.*',
+          'gym==0.21.*',
           'Click>=7.0',
           'numpy>=1.17.4',
           'cloudpickle>=1.2.2',


### PR DESCRIPTION
This update is required by https://github.com/AlignmentResearch/rllf to depend on magical and create custom environments for their research. However, it doesn't make any significant updates but rather updates the gym version requirement for magical which seems to pass the current test suite.